### PR TITLE
Remove zoom cruft directory

### DIFF
--- a/remove_zoom_macos.sh
+++ b/remove_zoom_macos.sh
@@ -213,6 +213,7 @@ declare -a ZOOM_CRUFT=(
     "/Users/$loggedInUser/Library/Application Support/zoom.us"
     "/Users/$loggedInUser/Library/Caches/us.zoom.xos"
     "/Users/$loggedInUser/Library/Cookies/us.zoom.xos.binarycookies"
+    "/Users/$loggedInUser/Library/HTTPStorages/us.zoom.xos"
     "/Users/$loggedInUser/Library/Logs/zoom.us"
     "/Users/$loggedInUser/Library/Logs/zoominstall.log"
     "/Users/$loggedInUser/Library/Logs/ZoomPhone"


### PR DESCRIPTION
Hey, thanks for creating this!

This PR adds a line that removes zoom-related sqlite database directory. This directory, as best I can tell, is [used by webkit](https://bugs.webkit.org/show_bug.cgi?id=210120).