### PR TITLE
Add additional Zoom LaunchAgent cleanup entries

### DIFF
--- a/remove_zoom_macos.sh
+++ b/remove_zoom_macos.sh
@@ -258,6 +258,8 @@ declare -a ZOOM_CRUFT=(
     /Users/"$loggedInUser"/Library/Group\ Containers/*.ZoomClient3rd
     /Users/"$loggedInUser"/Library/HTTPStorages/us.zoom.xos
     /Users/"$loggedInUser"/Library/HTTPStorages/us.zoom.xos.binarycookies
+    /Users/"$loggedInUser"/Library/LaunchAgents/us.zoom.updater.gui.501.plist
+    /Users/"$loggedInUser"/Library/LaunchAgents/us.zoom.updater.gui.501.login.check.plist
     /Users/"$loggedInUser"/Library/Logs/zoom.us
     /Users/"$loggedInUser"/Library/Logs/zoominstall.log
     /Users/"$loggedInUser"/Library/Logs/ZoomPhone

--- a/remove_zoom_macos.sh
+++ b/remove_zoom_macos.sh
@@ -258,8 +258,8 @@ declare -a ZOOM_CRUFT=(
     /Users/"$loggedInUser"/Library/Group\ Containers/*.ZoomClient3rd
     /Users/"$loggedInUser"/Library/HTTPStorages/us.zoom.xos
     /Users/"$loggedInUser"/Library/HTTPStorages/us.zoom.xos.binarycookies
-    /Users/"$loggedInUser"/Library/LaunchAgents/us.zoom.updater.gui.501.plist
-    /Users/"$loggedInUser"/Library/LaunchAgents/us.zoom.updater.gui.501.login.check.plist
+    /Users/"$loggedInUser"/Library/LaunchAgents/us.zoom.updater.gui.*.plist
+    /Users/"$loggedInUser"/Library/LaunchAgents/us.zoom.updater.gui.*.login.check.plist
     /Users/"$loggedInUser"/Library/Logs/zoom.us
     /Users/"$loggedInUser"/Library/Logs/zoominstall.log
     /Users/"$loggedInUser"/Library/Logs/ZoomPhone


### PR DESCRIPTION
This PR adds cleanup for two additional Zoom LaunchAgent files that are created by Zoom's auto-updater:

- us.zoom.updater.gui.501.plist
- us.zoom.updater.gui.501.login.check.plist

This can be reproduced :
- Download the Mac ARM Zoom App from `https://zoom.us/download?os=mac`. 
- **Choose to install only as the current user, not system-wide** 
- The installer (on 2025-07-29) installs `Version: 6.5.7 (60598)`.
- using FreeMacSoft AppCleaner.app, drag'n'drop the Zoom App. AppCleaner shows these files are part of the Zoom installation. See screenshot below.

<img width="1090" height="734" alt="Screenshot 2025-07-29 at 13 33 12" src="https://github.com/user-attachments/assets/ff84cdb0-31cb-46b6-b324-cab091d900ea" />

